### PR TITLE
feat: 画像の鮮明度計算のためのテーブル駆動テストを追加

### DIFF
--- a/internal/facedetector/detector.go
+++ b/internal/facedetector/detector.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"image"
-	"image/jpeg"
-	"image/png"
+	_ "image/jpeg"
+	_ "image/png"
 	"math"
 )
 
@@ -18,19 +18,10 @@ func CalculateSharpness(imageData []byte) (float64, error) {
 	}
 
 	// バイトスライスから画像をデコード
-	reader := bytes.NewReader(imageData)
-	img, _, err := image.Decode(reader)
+	// image.Decodeは、登録されたフォーマット（jpeg, pngなど）を自動的に検出します。
+	img, _, err := image.Decode(bytes.NewReader(imageData))
 	if err != nil {
-		// JPEGとPNGで再試行
-		reader.Seek(0, 0)
-		img, err = jpeg.Decode(reader)
-		if err != nil {
-			reader.Seek(0, 0)
-			img, err = png.Decode(reader)
-			if err != nil {
-				return 0, fmt.Errorf("画像のデコードに失敗しました: %v", err)
-			}
-		}
+		return 0, fmt.Errorf("画像のデコードに失敗しました: %v", err)
 	}
 
 	// グレースケール画像に変換

--- a/internal/facedetector/detector_test.go
+++ b/internal/facedetector/detector_test.go
@@ -1,0 +1,89 @@
+package facedetector
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCalculateSharpness(t *testing.T) {
+	// Read the image files
+	sharpImgData, err := os.ReadFile("../../test_large.png")
+	if err != nil {
+		t.Fatalf("failed to read sharp image: %v", err)
+	}
+
+	blurredImgData, err := os.ReadFile("../../test_blurred.png")
+	if err != nil {
+		t.Fatalf("failed to read blurred image: %v", err)
+	}
+
+	// Calculate sharpness for both images first to establish a baseline
+	sharpness, err := CalculateSharpness(sharpImgData)
+	if err != nil {
+		t.Fatalf("CalculateSharpness for sharp image failed: %v", err)
+	}
+
+	blurredSharpness, err := CalculateSharpness(blurredImgData)
+	if err != nil {
+		t.Fatalf("CalculateSharpness for blurred image failed: %v", err)
+	}
+
+	// Basic assertion that sharp is sharper than blurred
+	if sharpness <= blurredSharpness {
+		t.Errorf("expected sharp image to have higher sharpness than blurred image, got sharp: %f, blurred: %f", sharpness, blurredSharpness)
+	}
+
+	// Now, create table-driven tests for more specific checks
+	testCases := []struct {
+		name          string
+		input         []byte
+		expectErr     bool
+		checkSharpness func(t *testing.T, s float64)
+	}{
+		{
+			name:      "sharp image",
+			input:     sharpImgData,
+			expectErr: false,
+			checkSharpness: func(t *testing.T, s float64) {
+				if s <= blurredSharpness {
+					t.Errorf("sharpness of sharp image (%f) should be greater than blurred image (%f)", s, blurredSharpness)
+				}
+			},
+		},
+		{
+			name:      "blurred image",
+			input:     blurredImgData,
+			expectErr: false,
+			checkSharpness: func(t *testing.T, s float64) {
+				if s >= sharpness {
+					t.Errorf("sharpness of blurred image (%f) should be less than sharp image (%f)", s, sharpness)
+				}
+			},
+		},
+		{
+			name:      "empty data",
+			input:     []byte{},
+			expectErr: true,
+			checkSharpness: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sharpness, err := CalculateSharpness(tc.input)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+				if tc.checkSharpness != nil {
+					tc.checkSharpness(t, sharpness)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
facedetectorパッケージの `CalculateSharpness` 関数にテーブル駆動テストを導入します。

テストスイートは以下のケースをカバーしています:
- 鮮明な画像 (`test_large.png`)
- ぼやけた画像 (`test_blurred.png`)
- 適切なエラーハンドリングを確認するための空の画像データ

実装中に、`CalculateSharpness` の画像デコードロジックの問題が特定され、標準の `image.Decode` 関数を使用するように簡素化することで修正されました。さらに、元の `test.png` は1x1ピクセルの画像であることが判明したため、鮮明度のテストにより適した `test_large.png` に置き換えられました。