### PR TITLE
feat: 顔検出の可視化APIエンドポイントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ curl -X POST -F "image=@internal/facedetector/testdata/face_blurred.jpg" http://
 }
 ```
 
+### POST /detect/face/visualize
+
+アップロードされた画像から顔を検出し、その周りに四角い枠を描画して返します。
+
+**リクエスト:**
+- Content-Type: multipart/form-data
+- フィールド: `image` (画像ファイル)
+
+**レスポンス:**
+- Content-Type: image/png
+- ボディ: 顔の周りに赤い四角が描画された画像データ
+
+**テスト:**
+
+```bash
+curl -X POST -F "image=@internal/facedetector/testdata/face.jpg" http://localhost:8080/detect/face/visualize -o visualized_face.png
+```
+`visualized_face.png`というファイル名で、顔が四角で囲われた画像が保存されます。
+
 ## 使用可能なコマンド
 
 ```bash

--- a/internal/facedetector/detector_test.go
+++ b/internal/facedetector/detector_test.go
@@ -182,3 +182,72 @@ func TestCalculateFaceSharpness(t *testing.T) {
 		t.Logf("顔のない画像で期待どおりエラーを検出: %v", err)
 	}
 }
+
+func TestCropFace(t *testing.T) {
+	// 顔が検出される画像をテスト
+	faceImgData, err := os.ReadFile("testdata/face.jpg")
+	if err != nil {
+		t.Fatalf("顔画像の読み込みに失敗しました: %v", err)
+	}
+
+	croppedData, err := CropFace(faceImgData)
+	if err != nil {
+		t.Fatalf("CropFaceでエラーが発生しました: %v", err)
+	}
+
+	if len(croppedData) == 0 {
+		t.Errorf("出力された画像データが空です")
+	}
+
+	// 出力画像がデコード可能か確認
+	_, _, err = image.Decode(bytes.NewReader(croppedData))
+	if err != nil {
+		t.Errorf("出力画像のデコードに失敗しました: %v", err)
+	}
+
+	// 元の画像よりサイズが小さいことを確認
+	if len(croppedData) >= len(faceImgData) {
+		t.Errorf("切り抜かれた画像が元の画像より小さくありません")
+	}
+
+	// 顔が検出されない画像をテスト
+	noFaceImgData := createTestImage(100, 100, "solid") // 顔ではない画像
+	_, err = CropFace(noFaceImgData)
+	if err == nil {
+		t.Errorf("顔のない画像でエラーが返されませんでした")
+	} else {
+		t.Logf("顔のない画像で期待どおりエラーを検出: %v", err)
+	}
+}
+
+func TestDrawFaceRects(t *testing.T) {
+	// 顔が検出される画像をテスト
+	faceImgData, err := os.ReadFile("testdata/face.jpg")
+	if err != nil {
+		t.Fatalf("顔画像の読み込みに失敗しました: %v", err)
+	}
+
+	visualizedData, err := DrawFaceRects(faceImgData)
+	if err != nil {
+		t.Fatalf("DrawFaceRectsでエラーが発生しました: %v", err)
+	}
+
+	if len(visualizedData) == 0 {
+		t.Errorf("出力された画像データが空です")
+	}
+
+	// 出力画像がデコード可能か確認
+	_, _, err = image.Decode(bytes.NewReader(visualizedData))
+	if err != nil {
+		t.Errorf("出力画像のデコードに失敗しました: %v", err)
+	}
+
+	// 顔が検出されない画像をテスト
+	noFaceImgData := createTestImage(100, 100, "solid") // 顔ではない画像
+	_, err = DrawFaceRects(noFaceImgData)
+	if err == nil {
+		t.Errorf("顔のない画像でエラーが返されませんでした")
+	} else {
+		t.Logf("顔のない画像で期待どおりエラーを検出: %v", err)
+	}
+}


### PR DESCRIPTION
新しいAPIエンドポイント `/detect/face/visualize` を追加し、顔検出プロセスを可視化する機能を提供する。

このエンドポイントは、`output`クエリパラメータを受け付ける:
- `output=box` (デフォルト): 検出されたすべての顔の周りにバウンディングボックスを描画した画像を返す。
- `output=crop`: 検出された最も大きい顔を切り抜いた画像を返す。

この変更には、既存の顔検出ロジックを再利用するためのリファクタリングが含まれており、`detect/face`エンドポイントと新しい可視化エンドポイントで一貫した検出結果を保証する。